### PR TITLE
Improved asset loading and simplified rendering

### DIFF
--- a/src/main/java/com/github/jacksonhoggard/voodoo2d/engine/graphic/Mesh.java
+++ b/src/main/java/com/github/jacksonhoggard/voodoo2d/engine/graphic/Mesh.java
@@ -12,8 +12,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.lwjgl.opengl.GL11.*;
-import static org.lwjgl.opengl.GL13.GL_TEXTURE0;
-import static org.lwjgl.opengl.GL13.glActiveTexture;
 import static org.lwjgl.opengl.GL15.GL_ARRAY_BUFFER;
 import static org.lwjgl.opengl.GL15.GL_ELEMENT_ARRAY_BUFFER;
 import static org.lwjgl.opengl.GL15.GL_STATIC_DRAW;
@@ -172,24 +170,6 @@ public class Mesh {
         return vertexCount;
     }
 
-    public void render() {
-        // Activate firs texture bank
-        glActiveTexture(GL_TEXTURE0);
-        // Bind the texture
-        if(hasSpriteSheet)
-            glBindTexture(GL_TEXTURE_2D, spriteSheet.getTextures()[currentFrame].getId());
-        else
-            glBindTexture(GL_TEXTURE_2D, texture.getId());
-
-        // Draw the mesh
-        glBindVertexArray(getVaoId());
-
-        glDrawElements(GL_TRIANGLES, getVertexCount(), GL_UNSIGNED_INT, 0);
-
-        // Restore state
-        glBindVertexArray(0);
-    }
-
     public void cleanUp() {
         glDisableVertexAttribArray(0);
 
@@ -219,6 +199,10 @@ public class Mesh {
 
     public int getCurrentFrame() {
         return currentFrame;
+    }
+
+    public int getCurrentTextureId(){
+        return hasSpriteSheet ? spriteSheet.getTextures()[currentFrame].getId() : texture.getId();
     }
 
     public void setCurrentFrame(int currentFrame) {

--- a/src/main/java/com/github/jacksonhoggard/voodoo2d/engine/graphic/SpriteSheet.java
+++ b/src/main/java/com/github/jacksonhoggard/voodoo2d/engine/graphic/SpriteSheet.java
@@ -5,70 +5,59 @@ import com.github.jacksonhoggard.voodoo2d.engine.log.Log;
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.File;
-import java.io.IOException;
 
 public class SpriteSheet {
 
     public Texture[] textures;
 
     public SpriteSheet(String filename, int size) {
-        BufferedImage img = null;
         try {
-            img = ImageIO.read(new File(filename));
-        } catch(IOException e) {
-            Log.engine().error(e.getMessage());
-        }
+            BufferedImage img = ImageIO.read(new File(filename));
 
-        int rows = img.getHeight() / size;
-        int cols = img.getWidth() / size;
+            int rows = img.getHeight() / size;
+            int cols = img.getWidth() / size;
 
-        BufferedImage[] sprites = new BufferedImage[rows * cols];
+            BufferedImage[] sprites = new BufferedImage[rows * cols];
 
-        for(int i = 0; i < rows; i++) {
-            for(int j = 0; j < cols; j++) {
-                sprites[(i * cols) + j] = img.getSubimage(
-                  j * size,
-                  i * size,
-                  size,
-                  size
-                );
+            for (int i = 0; i < rows; i++) {
+                for (int j = 0; j < cols; j++) {
+                    sprites[(i * cols) + j] = img.getSubimage(
+                            j * size,
+                            i * size,
+                            size,
+                            size
+                    );
+                }
             }
-        }
 
-        try {
             textures = Texture.loadTexture(sprites);
-        } catch(Exception e) {
+        } catch (Exception e) {
             Log.engine().error(e.getMessage());
         }
     }
 
     public SpriteSheet(String filename) {
-        BufferedImage img = null;
         try {
-            img = ImageIO.read(new File(filename));
-        } catch(IOException e) {
-            Log.engine().error(e.getMessage());
-        }
+            BufferedImage img = ImageIO.read(new File(filename));
 
-        int rows = img.getHeight();
-        int cols = img.getWidth();
+            int rows = img.getHeight();
+            int cols = img.getWidth();
 
-        BufferedImage[] sprites = new BufferedImage[1];
+            BufferedImage[] sprites = new BufferedImage[1];
 
-        for(int i = 0; i < rows; i++) {
-            for(int j = 0; j < cols; j++) {
-                sprites[(i * cols) + j] = img.getSubimage(
-                        j * img.getWidth(),
-                        i * img.getHeight(),
-                        img.getWidth(),
-                        img.getHeight()
-                );
+            for (int i = 0; i < rows; i++) {
+                for (int j = 0; j < cols; j++) {
+                    sprites[(i * cols) + j] = img.getSubimage(
+                            j * img.getWidth(),
+                            i * img.getHeight(),
+                            img.getWidth(),
+                            img.getHeight()
+                    );
+                }
             }
-        }
 
-        try {
             textures = Texture.loadTexture(sprites);
-        } catch(Exception e) {
+        } catch (Exception e) {
             Log.engine().error(e.getMessage());
         }
     }

--- a/src/main/java/com/github/jacksonhoggard/voodoo2d/engine/mapping/Layer.java
+++ b/src/main/java/com/github/jacksonhoggard/voodoo2d/engine/mapping/Layer.java
@@ -9,12 +9,14 @@ import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
 
 public class Layer {
 
     private GameObject layer;
-    private int[][] layerCoords;
-    private int tileWidth, tileHeight;
+    private final int[][] layerCoords;
+    private final int tileWidth;
+    private final int tileHeight;
 
     public Layer(int[][] layerCoords, int x, int y, int tileWidth, int tileHeight, ArrayList<TileSet> tileSets) {
         this.layerCoords = layerCoords;
@@ -27,24 +29,32 @@ public class Layer {
 
         // Make the layer
         try {
-            for(int b = 0; b < y; b++) {
-                for(int a = 0; a < x; a++) {
-                    if(layerCoords[a][b] > 0) {
+            HashMap<String, BufferedImage> imageCache = new HashMap<>();
+            String basePath = String.format("src%smain%sresources%smaps%s", File.separator, File.separator, File.separator, File.separator);
+            for (int b = 0; b < y; b++) {
+                for (int a = 0; a < x; a++) {
+                    if (layerCoords[a][b] > 0) {
                         // Get the correct tileSet
                         TileSet currentTileSet = null;
                         for (TileSet tileSet : tileSets) {
                             if (layerCoords[a][b] >= tileSet.getFirstGID())
                                 currentTileSet = tileSet;
                         }
-                        BufferedImage tileSet = ImageIO.read(new File("src" + File.separator + "main"
-                                + File.separator + "resources" + File.separator +
-                                "maps" + File.separator + currentTileSet.getSource()));
+                        String path = basePath + currentTileSet.getSource();
+
+                        BufferedImage tileSet;
+                        if (imageCache.containsKey(path)) {
+                            tileSet = imageCache.get(path);
+                        } else {
+                            tileSet = ImageIO.read(new File(path));
+                            imageCache.put(path, tileSet);
+                        }
 
                         // Get subImage from tileset
                         BufferedImage subImage;
-                        for(int d = 0; d < currentTileSet.getGIDs()[0].length; d++) {
-                            for(int c = 0; c < currentTileSet.getGIDs().length; c++) {
-                                if(currentTileSet.getGIDs()[c][d] == layerCoords[a][b]) {
+                        for (int d = 0; d < currentTileSet.getGIDs()[0].length; d++) {
+                            for (int c = 0; c < currentTileSet.getGIDs().length; c++) {
+                                if (currentTileSet.getGIDs()[c][d] == layerCoords[a][b]) {
                                     subImage = tileSet.getSubimage(c * currentTileSet.getTileWidth(), d * currentTileSet.getTileHeight(), currentTileSet.getTileWidth(), currentTileSet.getTileHeight());
                                     layerTex = joinBufferedImage(layerTex, subImage, b, a);
                                 }

--- a/src/main/java/com/github/jacksonhoggard/voodoo2d/engine/mapping/MapHost.java
+++ b/src/main/java/com/github/jacksonhoggard/voodoo2d/engine/mapping/MapHost.java
@@ -3,6 +3,7 @@ package com.github.jacksonhoggard.voodoo2d.engine.mapping;
 import java.io.File;
 import java.util.ArrayList;
 
+
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
@@ -16,7 +17,7 @@ public class MapHost {
     private String tmxTarget;
     private NodeList rawTileData;
     private NodeList rawImageData;
-    private ArrayList<TileSet> tileSets = new ArrayList<TileSet>();
+    private ArrayList<TileSet> tileSets = new ArrayList<>();
     private static Map map;
 
     public MapHost(String tmxTarget){


### PR DESCRIPTION
# Description
## Renderer and Mesh changes 
 - Separation of concerns since there is a Render class it makes more sense for it to handle binding buffers/textures and drawing
 - Render can better handle opengl state avoiding state checks inside a mesh render function
 - Trimmed unnecessary opengl calls
## SpriteSheet
 - Potential NullPointerException if ImageIO.read() throws
 - Added all code into a single catch block since it is all being handled the same way
 - _SpriteSheet(String filename) is never used but I wasn't sure if it is for future imporvemts_
## Layer 
- Cache Images to avoid reading the same file from disk multiple times
- Resulted in a significant improvement on startup speed

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ✓] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [✓ ] I have performed a self-review of my own code
- [ ✓] I have commented my code, particularly in hard-to-understand areas
- [ X] I have added tests that prove my fix is effective or that my feature works
